### PR TITLE
Set include guard on import

### DIFF
--- a/nelder_mead.h
+++ b/nelder_mead.h
@@ -54,6 +54,7 @@
  *    https://github.com/develancer/nelder-mead/
  */
 #ifndef PTR_NELDER_MEAD_H
+#define PTR_NELDER_MEAD_H
 
 #include <array>
 #include <climits>


### PR DESCRIPTION
Header checks for include guards, but doesn't set the guard so repeat imports cause problems.

This will need to be cherry-picked to the simplex-size branch as well.